### PR TITLE
fix for R_LIBS env contamination into kernel discovery

### DIFF
--- a/icrn_manager
+++ b/icrn_manager
@@ -508,7 +508,7 @@ function register_r_library_in_user_catalog() # without unpacking, identify R ke
         # "R_HOME=''" ensures we don't get complaints from R that R_HOME is set, but we're calling a Rscript that isn't located there
         # we want to get a very plain readout of where this R install's main kernel is.
         echo "getting R path."
-	    target_kernel_path=$(R_HOME='' R_LIBS_USER='' R_LIBS_SITE='' $target_unpacked/bin/Rscript --vanilla -e 'cat(.libPaths()[1])')
+	    target_kernel_path=$(R_LIBS='' R_HOME='' R_LIBS_USER='' R_LIBS_SITE='' $target_unpacked/bin/Rscript --vanilla -e 'cat(.libPaths()[1])')
         echo "determined: $target_kernel_path"
         
         echo "Updating user's catalog with $target_kernel_path"

--- a/kernel-indexer/entrypoint.sh
+++ b/kernel-indexer/entrypoint.sh
@@ -15,7 +15,15 @@ DEFAULT_KERNEL_ROOT="/sw/icrn/jupyter/icrn_ncsa_resources/Kernels"
 
 # Environment variables with defaults
 KERNEL_ROOT="${KERNEL_ROOT:-${DEFAULT_KERNEL_ROOT}}"
-KERNEL_ROOT_HOST="${KERNEL_ROOT_HOST:-${KERNEL_ROOT}}"
+# When running in container with standard mount (/app/data), use host path for catalog entries
+# so catalog paths are valid on the host/NFS, not inside the container.
+if [ -n "${KERNEL_ROOT_HOST:-}" ]; then
+    : # use explicit KERNEL_ROOT_HOST
+elif [ "${KERNEL_ROOT}" = "/app/data" ]; then
+    KERNEL_ROOT_HOST="/sw/icrn/dev/kernels"
+else
+    KERNEL_ROOT_HOST="${KERNEL_ROOT}"
+fi
 OUTPUT_DIR="${OUTPUT_DIR:-${KERNEL_ROOT}}"
 LANGUAGE_FILTER="${LANGUAGE_FILTER:-}"
 LOG_LEVEL="${LOG_LEVEL:-INFO}"

--- a/tests/test_common.sh
+++ b/tests/test_common.sh
@@ -241,11 +241,13 @@ cleanup_test_env() {
 }
 
 # Function to set test environment variables
+# KERNEL_FOLDER must point to an existing directory or icrn_manager exits at startup.
 set_test_env() {
     export HOME="$TEST_USER_HOME"
     export ICRN_USER_BASE="$TEST_USER_HOME/.icrn"
     export ICRN_USER_KERNEL_BASE="$TEST_USER_HOME/.icrn/icrn_kernels"
     export ICRN_USER_CATALOG="$TEST_USER_HOME/.icrn/icrn_kernels/user_catalog.json"
+    export KERNEL_FOLDER="$TEST_REPO"
 }
 
 # Function to run icrn_manager with automatic confirmation for prompts

--- a/tests/test_config.sh
+++ b/tests/test_config.sh
@@ -82,9 +82,13 @@ test_config_validation_missing_repository() {
     local output
     output=$(icrn_manager_with_confirm kernels available 2>&1)
     
-    # Check if it fails with appropriate error - the script will try to read the catalog but fail
+    # Check if it fails with appropriate error. When KERNEL_FOLDER (still set to removed
+    # TEST_REPO) is no longer a directory, the script exits at startup with "Could not
+    # determine location of kernel respository". Otherwise we get main-block messages.
     if echo "$output" | grep -q "Couldn't locate.*kernel repository" || \
        echo "$output" | grep -q "Please contact support" || \
+       echo "$output" | grep -q "Could not determine location of kernel respository" || \
+       echo "$output" | grep -q "contact administrator" || \
        echo "$output" | grep -q "Could not open file" || \
        echo "$output" | grep -q "No such file or directory"; then
         return 0

--- a/tests/test_help.sh
+++ b/tests/test_help.sh
@@ -5,8 +5,10 @@
 source "$(dirname "$0")/test_common.sh"
 
 test_help_command() {
+    setup_test_env
+    set_test_env
     local output
-    output=$("$ICRN_MANAGER" help 2>&1)
+    output=$("$ICRN_MANAGER" help 2>&1 </dev/null)
     
     # Check if help shows usage information
     if echo "$output" | grep -q "usage:" && \
@@ -19,8 +21,10 @@ test_help_command() {
 }
 
 test_invalid_command() {
+    setup_test_env
+    set_test_env
     local output
-    output=$("$ICRN_MANAGER" invalid_command 2>&1)
+    output=$("$ICRN_MANAGER" invalid_command 2>&1 </dev/null)
     
     # Check if it fails with appropriate error message
     if echo "$output" | grep -q "Function.*not recognized" || \
@@ -33,8 +37,11 @@ test_invalid_command() {
 }
 
 test_kernels_help() {
+    setup_test_env
+    set_test_env
     local output
-    output=$("$ICRN_MANAGER" kernels 2>&1)
+    # kernels (no subcommand) triggers check_and_init_if_needed -> kernels__init which prompts; pipe "y"
+    output=$(printf 'y\n' | "$ICRN_MANAGER" kernels 2>&1)
     
     # Check if it shows error for missing subcommand
     if echo "$output" | grep -q "Error: No subcommand specified" || \


### PR DESCRIPTION
added kernel_root variable to enable indexing of kernels to the correct location on the host.
added R_LIBS to the set of env vars which are null'd when discovering the correct kernel path.